### PR TITLE
Set private flag to false for examples tracks

### DIFF
--- a/instruqt-tracks/aws-account/track.yml
+++ b/instruqt-tracks/aws-account/track.yml
@@ -10,6 +10,6 @@ owner: examples
 developers:
 - bruno@instruqt.com
 - sean@instruqt.com
-private: true
+private: false
 published: true
 checksum: "13353551960788857015"

--- a/instruqt-tracks/code-server-virtual-machine/track.yml
+++ b/instruqt-tracks/code-server-virtual-machine/track.yml
@@ -10,6 +10,6 @@ tags: []
 owner: examples
 developers:
 - sean@instruqt.com
-private: true
+private: false
 published: true
 checksum: "6952561371779095422"

--- a/instruqt-tracks/kubernetes-cluster-aks/track.yml
+++ b/instruqt-tracks/kubernetes-cluster-aks/track.yml
@@ -11,7 +11,7 @@ tags: []
 owner: examples
 developers:
 - sean@instruqt.com
-private: true
+private: false
 published: true
 skipping_enabled: true
 checksum: "17216431827672373997"

--- a/instruqt-tracks/kubernetes-cluster-eks/track.yml
+++ b/instruqt-tracks/kubernetes-cluster-eks/track.yml
@@ -13,6 +13,6 @@ tags: []
 owner: examples
 developers:
 - sean@instruqt.com
-private: true
+private: false
 published: true
 checksum: "1536039240951559644"

--- a/instruqt-tracks/kubernetes-cluster-gke/track.yml
+++ b/instruqt-tracks/kubernetes-cluster-gke/track.yml
@@ -11,6 +11,6 @@ tags: []
 owner: examples
 developers:
 - sean@instruqt.com
-private: true
+private: false
 published: true
 checksum: "17928750493971914869"

--- a/instruqt-tracks/multi-k8s-track/track.yml
+++ b/instruqt-tracks/multi-k8s-track/track.yml
@@ -13,7 +13,7 @@ tags:
 owner: examples
 developers:
 - sean@instruqt.com
-private: true
+private: false
 published: true
 show_timer: true
 checksum: "5209257787166920548"


### PR DESCRIPTION
See https://instruqt.slack.com/archives/C0113Q31LCE/p1658911182057529 for context.

This fix is needed to ensure all tracks are visible on the inspiration library with the team page v2 flag disabled. We need a proper fix for the inspiration library to ensure tracks remains visible after fully deprecating public access.